### PR TITLE
docs(plans): re-sequence product backlog into execution phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Local RAG system: document ingestion → vector index → retrieval → answer. 
 | Quick start, run commands, Makefile targets | `README.md`, `Makefile` |
 | Dev setup, test suites, CI/release flow, env vars | `docs/dev_test_CI/README.md` |
 | Docker stack management, volumes, reset | `docs/operate/docker-management.md` |
+| Auto-merge, branch rulesets, required CI checks | `docs/operate/auto-merge.md` |
 
 ## Critical Rules
 

--- a/docs/operate/auto-merge.md
+++ b/docs/operate/auto-merge.md
@@ -1,0 +1,61 @@
+# Auto-Merge for `main`
+
+> PRs targeting `main` merge themselves once required CI checks pass — no manual "Enable auto-merge" click. This guide documents how that works and how to operate it.
+
+## How it works
+
+Two independent pieces combine:
+
+1. **Gate** — branch rulesets block a PR from merging until checks pass.
+2. **Arming** — a workflow turns on GitHub's auto-merge for every eligible PR, so it merges automatically the moment the gate clears.
+
+```
+PR opened/reopened/ready against main
+  └─> .github/workflows/enable-automerge.yml arms auto-merge (merge commit)
+        └─> GitHub holds the merge until ALL required gates are green:
+              ├─ ruleset "Require CI tests on main": Lint, Pyright, Unit Tests,
+              │                                       Deptry dependency health, Sec Scan
+              └─ ruleset "protect Main and Dev":      CodeQL + Copilot review
+        └─> all green -> GitHub merges via merge commit
+```
+
+## The pieces
+
+### Repo setting
+- **Allow auto-merge** must stay enabled (Settings → General → Pull Requests).
+  Check: `gh api repos/KristjanHS/kri-local-rag --jq '.allow_auto_merge'` → `true`.
+
+### Workflow — `.github/workflows/enable-automerge.yml`
+- Trigger: `pull_request_target` on `[opened, reopened, ready_for_review]`, `branches: [main]`.
+- Uses `pull_request_target` (not `pull_request`) so the **base-branch** copy of the workflow always runs — covering PRs from branches cut before it existed — and it never checks out PR code, so the write-scoped token is not exposed.
+- Skips drafts (`if: !github.event.pull_request.draft`). Mark a draft **Ready for review** to arm it.
+- Runs `gh pr merge --auto --merge` (merge commit, per the `dev`-is-permanent-integration convention).
+
+### Rulesets (the gate)
+| Ruleset | Applies to | Enforces |
+|---------|-----------|----------|
+| **Require CI tests on main** | `main` only | required status checks: Lint, Pyright, Unit Tests, Deptry dependency health, Sec Scan |
+| **protect Main and Dev** | `main`, `dev` | PR required (0 approvals), CodeQL code-scanning, Copilot review, no deletion / force-push |
+
+Inspect: `gh api repos/KristjanHS/kri-local-rag/rulesets` then `…/rulesets/<id>`.
+
+## Why only those 5 checks are required
+
+A required status check that is **skipped** (path-filtered or excluded) on a given PR stays *pending forever* and freezes the merge. Only checks that run on **every** PR to `main` are safe to require:
+
+- ✅ Required (no path filter): Lint, Pyright, Unit Tests, Deptry, Sec Scan.
+- ❌ Not required (path-filtered — would freeze unrelated PRs): Actionlint / Yamlfmt / Hadolint (yml/Dockerfile only), uv audit / Trivy FS (dep/Docker only).
+- Integration / E2E / UI tests are **excluded from GitHub CI by design** (they run locally via `act`) — never require them.
+
+CodeQL is already gated by the `code_scanning` rule in "protect Main and Dev", so it is not duplicated in the status-check list.
+
+## Operating notes
+
+- **PR sits green but `BLOCKED`?** Most likely waiting on the Copilot review from "protect Main and Dev". Confirm with `gh pr checks <n>` and the PR's "merge box".
+- **Add/remove a required check:** edit the "Require CI tests on main" ruleset. Only add checks that run on every PR (see above).
+- **Disable auto-merge temporarily:** disable the ruleset's enforcement, or set the workflow to draft-only — do not rely on memory; the gate is what guarantees tests pass.
+- **Manual one-off arm** (e.g. before the workflow reaches a branch): `gh pr merge <n> --auto --merge`.
+
+## Bootstrapping a brand-new clone of this setup
+
+The arming workflow must already exist on `main` to arm PRs into `main`. The first PR that *introduces* the workflow can't self-arm — arm it manually once (`gh pr merge <n> --auto --merge`); every PR after it self-arms.

--- a/docs/plans/archive/2026-06-23-python-3.14-upgrade.md
+++ b/docs/plans/archive/2026-06-23-python-3.14-upgrade.md
@@ -1,6 +1,7 @@
 # Plan: Upgrade project Python 3.12 → 3.14
 
-Status: **UNBLOCKED — ready to execute (verified 2026-06-23)**. Project currently shipped on 3.13. Owner: TBD.
+Status: **SHIPPED (2026-06-23)**. The upgrade was executed and merged (PR #138, "Promote dev: … 3.14 runtime …"): `requires-python = ">=3.14,<3.15"` and the Docker images are on `python:3.14`. Archived. (Original status header below preserved for history.)
+Status (historical): **UNBLOCKED — ready to execute (verified 2026-06-23)**. Project currently shipped on 3.13. Owner: TBD.
 The original blocker (`unstructured[pdf]` requires-python `<3.14`) was dissolved by an unrelated change: the pypdf migration (`e0a23c2`) removed `unstructured[pdf]`/`unstructured-inference` entirely, and the transformers 5.x security bump (`f05d77c`) moved off the last 4.x deps. Empirically re-verified against 3.14.6 — see resolution note below.
 
 ## ✅ Blocker RESOLVED (re-verified 2026-06-23 against CPython 3.14.6)

--- a/docs/plans/product_todo.md
+++ b/docs/plans/product_todo.md
@@ -49,7 +49,20 @@ This file tracks **outstanding / undone** tasks for the project. Completed work
 
 ## Prioritized Backlog
 
-#### P2 — Complete Application Validation After Model Changes (IN PROGRESS)
+> **Execution order (set 2026-06-23).** Work the items in *phase* order (A→D), not
+> P-number order. P-numbers are retained as stable IDs. Dependency spine: **P5 is the
+> root-cause keystone** — fixing the Weaviate collection/schema mismatch unblocks the P3
+> blockers and removes most P2 E2E failures. P5/P3/P2 overlap heavily; treat them as one
+> effort, not three.
+>
+> | Phase | Item(s) | Why here |
+> |-------|---------|----------|
+> | **A** | P5 **(+ P3 Step 7 folded in)** | Fix the Weaviate collection/schema root cause. Pull P3 Step 7 (diagnostics & isolation) forward as the instrumentation that makes P5 debugging actionable. |
+> | **B** | P3 Steps 6, 8 | With P5 green, verify build-reuse (Step 6) and wire the containerized CLI subset into scripts/docs/CI (Step 8). Also satisfies P2's Integration-Suite / Docker-Env / Docs sub-items. |
+> | **C** | P2 (remaining gaps) | Full app-validation sweep as *confirmation*, skipping what A+B already covered. Model-loading layers (Integration Suite, Real Model Ops) are independent of P5 and can run anytime. |
+> | **D** | P7 | Low-value / partly moot — **defer** unless Phase C surfaces a concrete compile-time pain point. |
+
+#### P2 — Complete Application Validation After Model Changes (PHASE C — confirmation sweep, IN PROGRESS)
 
 **Goal**: Validate that the entire RAG application works correctly after the comprehensive
 model handling refactoring, ensuring no regressions were introduced.
@@ -122,7 +135,7 @@ network dependency for downloads · Docker build time · test flakiness from rea
 
 ---
 
-#### P3 — Containerized CLI E2E copies (Steps 6–8 remaining)
+#### P3 — Containerized CLI E2E copies (PHASE B — Steps 6 & 8; Step 7 pulled into Phase A)
 
 **Already done** (see archive): Steps 1–5 — the CLI-twin infrastructure using the existing
 `app` container (`run_cli_in_container` helper, removed separate `cli` service, one passing
@@ -137,7 +150,7 @@ twin `test_qa_real_end_to_end_container_e2e.py`).
   - Verify: second run is faster due to image reuse. *(Partially verified — build works,
     but tests fail on the Weaviate blockers below.)*
 
-- [ ] **Step 7 — Diagnostics and isolation**
+- [ ] **Step 7 — Diagnostics and isolation** *(PULLED INTO PHASE A — build first, then use it to debug P5)*
   - Action: on failure, print exit code, last 200 lines of app logs, and tails of
     `weaviate`/`ollama` logs; use ephemeral dirs/volumes.
   - Verify: failures are actionable; runs are deterministic and isolated.
@@ -162,11 +175,17 @@ twin `test_qa_real_end_to_end_container_e2e.py`).
 
 ---
 
-#### P5 — E2E retrieval failure: QA test returns no context (Weaviate)
+#### P5 — E2E retrieval failure: QA test returns no context (Weaviate) — **PHASE A — DO FIRST (keystone)**
 
 > **Note**: same root cause as the P3 blockers above (collection/schema mismatch). Resolve
 > together. Likely mismatch between the collection name used by retrieval vs. ingestion, or
 > ingestion not executed.
+>
+> **Phase A folds in P3 Step 7.** Build the P3 Step 7 diagnostics/isolation harness (exit
+> code + app/`weaviate`/`ollama` log tails on failure, ephemeral volumes) *before* cracking
+> P5 — it turns the "no context returned" failure into an actionable trace. The load-bearing
+> fix in this phase is **Task 5: standardize on one E2E collection name** across tests,
+> fixtures, and config; the other tasks are diagnosis around it.
 
 - [ ] **Task 1 — Reproduce quickly**
   - Action: run only the failing test (e.g. `pytest tests/e2e/test_qa_real_end_to_end.py`).
@@ -204,7 +223,7 @@ twin `test_qa_real_end_to_end_container_e2e.py`).
 
 ---
 
-#### P7 — Torch.compile Optimization (Tasks 2–4 remaining, low priority)
+#### P7 — Torch.compile Optimization (PHASE D — DEFERRED; Tasks 2–4 remaining, low priority)
 
 **Already done** (see archive): `.env` fix, reduced verbosity, in-process re-compile guard,
 and **Task 1 is moot** — the torch.compile logic was refactored into `backend/ingest.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ exclude = [".git", "__pycache__", ".venv", "venv", "build", "dist"]
 # NOT auto-adopt 3.14-only syntax (e.g. PEP 758 parenthesis-free `except A, B:`),
 # which would be a SyntaxError under a rollback to the 3.13 floor and breaks the
 # atomic single-revert guarantee of the 3.14 bump. Adopting 3.14 syntax is a
-# separate task — see docs/plans/2026-06-23-python-3.14-upgrade.md "Out of scope".
+# separate task — see docs/plans/archive/2026-06-23-python-3.14-upgrade.md "Out of scope".
 target-version = "py313"
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

Re-sequences `docs/plans/product_todo.md` into **execution-phase order (A–D)** instead of P-number order, so the backlog reads in the order work should actually happen.

- **Phase A** — P5 (Weaviate collection/schema mismatch) is the root-cause keystone; **P3 Step 7** (diagnostics/isolation) is folded in as the instrumentation to debug it. Load-bearing fix: standardize on one E2E collection name (P5 Task 5).
- **Phase B** — P3 Steps 6 & 8 (build-reuse verify, wire containerized CLI into scripts/docs/CI).
- **Phase C** — P2 full-validation sweep as confirmation (model-loading layers are independent of P5).
- **Phase D** — P7 torch.compile deferred (low-value / partly moot).

Docs-only change. Added an execution-order overview table at the top of the backlog and tagged each section header with its phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)