### PR TITLE
Merge dev: torch.compile cleanup, thread-safe debug logging, test-env config

### DIFF
--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -24,9 +24,8 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, List, Optional, Protocol, TypeVar, cast, runtime_checkable
+from typing import Any, List, Optional, Protocol, cast, runtime_checkable
 
-import torch
 import weaviate
 from langchain_core.documents import Document
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -250,36 +249,6 @@ def process_and_upload_chunks(
     logger.info(f"Batch ingestion complete: {total_chunks} chunks processed.")
 
 
-TModel = TypeVar("TModel", bound=SupportsEncode)
-
-
-def optimize_embedding_model(embedding_model: TModel) -> TModel:
-    """Compile the embedding model with torch.compile if not already compiled.
-
-    Adds a private marker attribute on the compiled instance to avoid duplicate work/logs.
-    """
-    if bool(getattr(embedding_model, "_is_torch_compiled", False)):
-        return embedding_model
-
-    try:
-        logger.info("torch.compile: optimizing embedding model – this may take a minute on first run…")
-        torch_compile = getattr(torch, "compile")
-        compiled_model = cast(
-            TModel,
-            torch_compile(embedding_model, backend="inductor", mode="max-autotune"),
-        )
-        # Mark the compiled instance so future calls are a no-op.
-        try:
-            setattr(compiled_model, "_is_torch_compiled", True)  # type: ignore[attr-defined]
-        except (AttributeError, TypeError) as attr_err:
-            logger.debug("Could not set _is_torch_compiled flag on compiled model: %s", attr_err)
-        logger.info("torch.compile optimization completed.")
-        return compiled_model
-    except Exception as e:
-        logger.warning(f"Could not apply torch.compile: {e}")
-        return embedding_model
-
-
 def ingest(
     directory: str,
     collection_name: str,
@@ -290,9 +259,6 @@ def ingest(
 ):
     """Main ingestion pipeline."""
     start_time = time.time()
-
-    # Apply torch.compile optimization to the embedding model (idempotent)
-    embedding_model = optimize_embedding_model(embedding_model)
 
     chunked_docs = load_and_split_documents(directory)
     if not chunked_docs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -76,8 +76,8 @@ services:
         INSTALL_EDITABLE: "1"
 
     ports:
-      # Parametrized so the test stack's app-test (which inherits this via `extends`)
-      # lands on a distinct host port instead of colliding with the live app on 8501.
+      # app-test inherits this via `extends` but overrides with `ports: []`, so it
+      # publishes nothing and never collides with the live app on 8501.
       - "8501:8501"
     volumes:
       - ../backend:/app/backend # Live backend code (for editable runtime package in Dev)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,13 +9,9 @@ services:
     # originally motivated this directive is now fixed at the source via
     # CLUSTER_IN_LOCALHOST below (memberlist binds to 127.0.0.1, always up at boot).
     restart: on-failure
-    # Host ports are parametrized so the `test` profile can run alongside the live
-    # stack on distinct ports (scripts/dev/test-env.sh sets the *_HOST_PORT vars).
-    # Container-side ports stay fixed at 8080/50051 — internal DNS and healthchecks
-    # are unaffected.
     ports:
-      - "127.0.0.1:${WEAVIATE_HTTP_HOST_PORT:-8080}:8080"
-      - "127.0.0.1:${WEAVIATE_GRPC_HOST_PORT:-50051}:50051"
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:50051:50051"
     volumes:
       - weaviate_db:/var/lib/weaviate
     environment:
@@ -59,7 +55,7 @@ services:
     volumes:
       - ../model_cache:/root/.ollama
     ports:
-      - "127.0.0.1:${OLLAMA_HOST_PORT:-11434}:11434"
+      - "127.0.0.1:11434:11434"
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 10s
@@ -82,11 +78,13 @@ services:
     ports:
       # Parametrized so the test stack's app-test (which inherits this via `extends`)
       # lands on a distinct host port instead of colliding with the live app on 8501.
-      - "${APP_HOST_PORT:-8501}:8501"
+      - "8501:8501"
     volumes:
       - ../backend:/app/backend # Live backend code (for editable runtime package in Dev)
       - ../frontend:/app/frontend # Live frontend code            (for hot reload in Dev)
       - ../tests:/app/tests:ro # Live tests for in-container testing
+      - ../pyproject.toml:/app/pyproject.toml:ro # Integration test config ([tool.integration])
+      - ../cli.py:/app/cli.py:ro # CLI entrypoint exercised by integration tests
       - ../data:/app/data # Live data access (read-write: GUI ingest writes uploaded PDFs here)
       - ../example_data:/app/example_data:ro # Ensure example_data matches project layout
     working_dir: /app

--- a/docs/plans/2026-06-24-complexity-hotspots-simplification.md
+++ b/docs/plans/2026-06-24-complexity-hotspots-simplification.md
@@ -33,12 +33,12 @@ the day Ollama changes its API.
 | 9 | Duplicated `RAG_FAKE_ANSWER` bypass | qa_loop.py:137 + rag_app.py:27-29,245 | MEDIUM | Two char-streaming fake paths |
 | 10 | Debug-log spam per token/line | ollama_client.py:185-234 | MEDIUM | ~20 debug calls, one per token |
 | 11 | Three URL-resolution mechanisms | config.py:183-204 + ollama_client.py:16-28 | MEDIUM | `get_service_url` + consts + `_get_ollama_base_url` |
-| 12 | `optimize_embedding_model` torch.compile | ingest.py:256-280 | MEDIUM | max-autotune + marker-attr hack on CPU MiniLM |
+| 12 | `optimize_embedding_model` torch.compile | ingest.py:256-280 | MEDIUM | ✅ DONE 2026-06-24 — proven no-op (`.encode()` bypasses compiled forward); removed fn + call + `torch` import |
 | 13 | `connect_to_weaviate` "deprecated" shim | ingest.py:155-158 | MEDIUM | Comment lies; it's the live path |
 | 14 | Three logging config entry points | config.py + qa_loop.py:30-46 | MEDIUM | `_setup_logging`/`set_log_level`/`_setup_cli_logging` |
 | 15 | `load_and_split_documents` dual path | ingest.py:86-149 | MEDIUM | file-branch & dir-branch duplicate logic |
 | 16 | Duplicated PDF magic-byte validation | ingest.py:63-69 + rag_app.py:138 | MEDIUM | Two impls of the same 5-byte check |
-| 17 | `SupportsEncode`/`TModel`/`runtime_checkable` | ingest.py:41-44,253 | LOW | Protocol+TypeVar for one concrete class |
+| 17 | `SupportsEncode`/`TModel`/`runtime_checkable` | ingest.py:41-44,253 | LOW | Partial: `TModel` removed with #12 (2026-06-24); `SupportsEncode`/`runtime_checkable` still used |
 | 18 | Re-sort of already-sorted results | retriever.py:122-124 | LOW | "just in case" sort on dubious key |
 | 19 | Over-defensive `getattr`/`cast` on `Document` | ingest.py:179,206 | LOW | `.metadata` always exists |
 | 20 | Dead comments describing non-behavior | ingest.py:224-235 | LOW | 3 comment blocks on upsert we don't do |
@@ -313,7 +313,9 @@ code from `qa_loop`, so it does not collide with the A2 split.
    anyway (no Weaviate vectorizer configured), so deleting it is strictly safe.
 5. **A2 split first**, then **#6, #8, #9, #22 fall out** of it. **#7** (Streamlit logging) is
    independent structural work — slot alongside.
-6. **Remainder as capacity allows:** #10, #12, #15, #17, #23, #24, A3.
+6. **Remainder as capacity allows:** #10, #15, #17, #23, #24, A3. (**#12 shipped 2026-06-24** —
+   see table; surfaced while investigating the `torch.jit.script_method` 3.14 deprecation warning,
+   whose sole trigger was this dead `torch.compile` call.)
 
 ### Re-work note
 Only **#5** (touches `answer()` params) edits `qa_loop` before A2 relocates that code; it is

--- a/docs/plans/2026-06-24-test-env-fixed-project-name.md
+++ b/docs/plans/2026-06-24-test-env-fixed-project-name.md
@@ -21,10 +21,13 @@ returns:
    live-stack model.
 
 2. **Fixed host ports make concurrent stacks impossible anyway.** Since
-   `84d8344`, every test stack binds the same host ports (18080 / 50052 /
-   21434 / 18501). Two test stacks at once collide on those ports regardless of
-   project name. The one capability the unique id exists for is already blocked
-   by the port scheme — the two features work against each other.
+   `84d8344`, every test stack binds the same host ports (originally 18080 /
+   50052 / 21434 / 18501; **later converged to the live ports 8080 / 50051 /
+   11434 / 8501** — the test stack now reuses the live ports outright, so it
+   can't run alongside the live stack either). Two test stacks at once collide on
+   those ports regardless of project name. The one capability the unique id
+   exists for is already blocked by the port scheme — the two features work
+   against each other.
 
 3. **CI doesn't need it.** The `integration`/`e2e` jobs each run on their own
    fresh `ubuntu-latest` VM (and are `nektos/act`-gated), so they are isolated

--- a/frontend/rag_app.py
+++ b/frontend/rag_app.py
@@ -264,10 +264,15 @@ if submitted and question.strip():
                 raise
 
             # Route backend diagnostics into the debug panel via logging (replaces on_debug).
-            # Temporarily lower the module logger to DEBUG so its records reach the handler.
+            # Raise the module logger to DEBUG so its records reach the handler. This is done
+            # idempotently and NOT restored: the logger is a process-wide singleton shared by
+            # every Streamlit session thread, so restoring a prior level in this thread's
+            # finally would silence DEBUG for a concurrent thread still inside answer(). DEBUG
+            # records are still filtered out at the root handler (INFO) and the per-thread
+            # _DebugPanelHandler only feeds this session's panel, so leaving it on is safe.
             ollama_logger = logging.getLogger("backend.ollama_client")
-            prev_level = ollama_logger.level
-            ollama_logger.setLevel(logging.DEBUG)
+            if ollama_logger.level > logging.DEBUG or ollama_logger.level == logging.NOTSET:
+                ollama_logger.setLevel(logging.DEBUG)
             debug_handler = _DebugPanelHandler(threading.get_ident(), debug_placeholder)
             ollama_logger.addHandler(debug_handler)
             try:
@@ -281,7 +286,6 @@ if submitted and question.strip():
                 )
             finally:
                 ollama_logger.removeHandler(debug_handler)
-                ollama_logger.setLevel(prev_level)
     # After streaming, keep showing the debug info
     debug_placeholder.text("\n".join(st.session_state["debug_lines"]))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,9 +225,6 @@ filterwarnings = [
     "error::DeprecationWarning:frontend",
     "error::PendingDeprecationWarning:backend",
     "error::PendingDeprecationWarning:frontend",
-    # Third-party noise: torch's own internals emit this when sentence-transformers
-    # loads a TorchScript model (one burst per model load). Not actionable here.
-    "ignore:`torch.jit.script_method` is deprecated:DeprecationWarning",
 ]
 
 [tool.deptry]

--- a/scripts/dev/test-env.sh
+++ b/scripts/dev/test-env.sh
@@ -7,11 +7,9 @@ set -euo pipefail
 # mirroring how the live stack reuses "kri-local-rag". up/down/clean operate on
 # that one project; there is no per-run id to mint, persist, or orphan.
 #
-# Concurrency note: running N isolated test stacks on one host is intentionally
-# NOT supported. The fixed host ports below already block it (two stacks collide
-# on the same ports regardless of project name). If concurrent stacks are ever
-# wanted back, a per-run project name AND per-run ports must return together —
-# the two features are coupled; reviving one without the other is a no-op.
+# The test stack reuses the same host ports as the live stack (8080/50051/11434/8501),
+# so the two cannot run at the same time — by design, since they're never needed
+# concurrently. `make test-down`/`make stack-down` the other one first.
 
 LOG_DIR=${LOG_DIR:-logs}
 BUILD_HASH_FILE=${BUILD_HASH_FILE:-.test-build.hash}
@@ -24,18 +22,6 @@ BUILD_DEPS=(pyproject.toml uv.lock docker/app.Dockerfile docker/docker-compose.y
 TEST_IMAGE=${TEST_IMAGE:-kri-local-rag-app:test}
 # Centralized service list used by up/logs
 SERVICES=(weaviate ollama app-test)
-
-# Distinct host ports so the test stack can run alongside the live stack (which uses
-# the compose defaults 8080/50051/11434). Container-side ports are unchanged, so the
-# in-network DNS used by app-test (weaviate:8080, ollama:11434) is unaffected. Override
-# if these collide with something else on the host.
-export WEAVIATE_HTTP_HOST_PORT=${WEAVIATE_HTTP_HOST_PORT:-18080}
-export WEAVIATE_GRPC_HOST_PORT=${WEAVIATE_GRPC_HOST_PORT:-50052}
-export OLLAMA_HOST_PORT=${OLLAMA_HOST_PORT:-21434}
-# app-test inherits app's port mapping via `extends`; give it a distinct host port
-# (it runs `tail -f /dev/null`, so nothing actually serves here — this only avoids a
-# bind collision with the live app on 8501).
-export APP_HOST_PORT=${APP_HOST_PORT:-18501}
 
 # Minimal logging helpers
 log() { echo "$*"; }

--- a/scripts/docker/docker-setup.sh
+++ b/scripts/docker/docker-setup.sh
@@ -82,9 +82,21 @@ APP_BUILD_HASH_FILE="${APP_BUILD_HASH_FILE:-.app-build.hash}"
 APP_BUILD_DEPS=(pyproject.toml uv.lock docker/app.Dockerfile docker/docker-compose.yml)
 FORCE_BUILD="${FORCE:-0}"
 
+# Emit a sha256 digest of stdin/args, portable across Linux (sha256sum) and macOS (shasum).
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$@"
+    else
+        log ERROR "Neither sha256sum nor shasum is available; cannot hash build inputs." | tee -a "$LOG_FILE"
+        return 1
+    fi
+}
+
 build_app_if_needed() {
     local new_hash old_hash=""
-    new_hash=$(sha256sum "${APP_BUILD_DEPS[@]}" | sha256sum | awk '{print $1}')
+    new_hash=$(sha256 "${APP_BUILD_DEPS[@]}" | sha256 | awk '{print $1}') || return 1
     if [ -f "$APP_BUILD_HASH_FILE" ]; then
         old_hash=$(<"$APP_BUILD_HASH_FILE")
     fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,18 +53,30 @@ def _ensure_logs_dir() -> Iterator[None]:
 
 
 def get_integration_config() -> dict[str, Any]:
-    """Read integration config from pyproject.toml (service health endpoints/timeouts)."""
+    """Read integration config from pyproject.toml (service health endpoints/timeouts).
+
+    Resolve pyproject.toml relative to the repo (this file lives at <repo>/tests/),
+    not the CWD. In-container test runs have CWD=/app with no pyproject there, so a
+    CWD-relative open silently returns {} and every service-gated test skips with a
+    misleading "service not available" message even when the services are healthy.
+    """
     try:
         import tomllib  # Python 3.11+
     except ImportError:
         return {}
 
-    try:
-        with open("pyproject.toml", "rb") as f:
-            config = tomllib.load(f)
-        return config.get("tool", {}).get("integration", {})
-    except Exception:
-        return {}
+    # Prefer the repo-root pyproject (CWD-independent); fall back to CWD.
+    candidates = [Path(__file__).resolve().parent.parent / "pyproject.toml", Path("pyproject.toml")]
+    for pyproject in candidates:
+        try:
+            with open(pyproject, "rb") as f:
+                config = tomllib.load(f)
+            return config.get("tool", {}).get("integration", {})
+        except FileNotFoundError:
+            continue
+        except Exception:
+            return {}
+    return {}
 
 
 def is_http_service_available(url: str, timeout: float = 2.0) -> bool:

--- a/tests/unit/test_compose_security.py
+++ b/tests/unit/test_compose_security.py
@@ -23,9 +23,8 @@ def test_compose_service_ports_binding_security() -> None:
     ollama_ports = services.get("ollama", {}).get("ports", [])
     app_ports = services.get("app", {}).get("ports", [])
 
-    # Host ports are parametrized (e.g. "127.0.0.1:${WEAVIATE_HTTP_HOST_PORT:-8080}:8080")
-    # so the test profile can run on distinct host ports. The security property is the
-    # loopback (127.0.0.1) binding prefix; the container-side port suffix stays fixed.
+    # The security property is the loopback (127.0.0.1) binding prefix; the
+    # container-side port suffix is what we assert on.
     def binds_loopback(ports: list[object], container_port: int) -> bool:
         return any(str(p).startswith("127.0.0.1:") and str(p).endswith(f":{container_port}") for p in ports)
 


### PR DESCRIPTION
Syncs `dev` into `main`. Four commits:

- **refactor(ingest): drop dead `torch.compile` embedding optimization** — `optimize_embedding_model()` wrapped the SentenceTransformer in `torch.compile(inductor, max-autotune)`, but ingest only calls `model.encode()`, which routes through the *original* (uncompiled) forward (`comp.encode.__func__ is m.encode.__func__`). Zero throughput benefit; its only effect was importing `torch.utils.mkldnn`, whose `@torch.jit.script_method` classes emit a Python-3.14 `DeprecationWarning`. Removed the function, its call, the `_is_torch_compiled` marker, unused `torch`/`TypeVar`/`TModel`, and the obsolete `filterwarnings` ignore. Resolves complexity hotspot #12.
- **fix(review): thread-safe debug logging + portable sha256 in setup** — Streamlit debug-panel logger no longer restores a shared singleton's level in a per-thread `finally` (would silence a concurrent session); `docker-setup.sh` gains a portable `sha256` helper (sha256sum/shasum).
- **fix(test): load integration config in-container; converge test/live ports** (×2) — integration config resolves repo-root `pyproject.toml` (CWD-independent); `app-test` publishes no host port (overrides with `ports: []`).

Verification: unit suite 47 passed; ruff + pyright clean; the `torch.jit.script_method` warning no longer fires on the ingest path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)